### PR TITLE
Style changes for lint test

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,11 +11,6 @@ COPY pyproject.toml poetry.lock* ./
 # Configure poetry to not use a virtual environment
 RUN poetry config virtualenvs.create false
 
-#Gets Google generative AI and other dependencies for testing
-RUN pip install google-generativeai
-RUN pip install dotenv
-RUN pip install asyncio
-
 # Install dependencies based on environment
 ARG ENVIRONMENT=development
 RUN if [ "$ENVIRONMENT" = "production" ] ; then poetry install --no-dev --no-root ; else poetry install --no-root ; fi

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,14 @@
-from fastapi import FastAPI, Body, HTTPException
+"""
+This module provides utility for the backend
+This encases the main function for the backend
+"""
+import os
+import asyncio
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import google.generativeai as genai
-import os
 from dotenv import load_dotenv
-import asyncio
 
 # Load environment variables
 load_dotenv()
@@ -32,44 +36,49 @@ app.add_middleware(
 )
 
 class ChatMessage(BaseModel):
+    """
+    This class provides utility for the chatbot message
+    Input: BaseModel - AI model to be used for the interface
+    """
     message: str
 
 @app.get("/")
 async def root():
+    """Returns a message referencing the API"""
     return {"message": "Welcome to ThreadFlow API"}
 
 @app.get("/health")
 async def health_check():
+    """Returns a message referencing the health of the API"""
     return {"status": "healthy"}
 
 @app.post("/chat")
 async def chat(message: ChatMessage):
+    """Asynchronous method for the chat interface"""
     try:
         # Check if API key is configured
         if not GEMINI_API_KEY:
             return {
-                "response": "API key not configured. Please set GEMINI_API_KEY in your environment variables."
+                "response": '''API key not configured.
+                 Please set GEMINI_API_KEY in your environment variables.'''
             }
-        
         # Wrap the synchronous API call in an executor to prevent blocking
         # The Google GenerativeAI library is synchronous, so we need to run it in a thread pool
         loop = asyncio.get_event_loop()
         response = await loop.run_in_executor(
-            None, 
+            None,
             lambda: model.generate_content(message.message)
         )
-        
         # Extract the text from the response
         response_text = response.text
-        
         return {
             "response": response_text
         }
-    except Exception as e:
+    except HTTPException as excp_err:
         # Log the error
-        print(f"Error calling Gemini API: {str(e)}")
-        
+        print(f"Error calling Gemini API: {str(excp_err)}")
         # Return a user-friendly error message
         return {
-            "response": f"Sorry, I encountered an error while processing your request: {str(e)}"
+            "response": f"""Sorry, I encountered an error while
+              processing your request: {str(excp_err)}"""
         }

--- a/backend/app/test_api.py
+++ b/backend/app/test_api.py
@@ -1,22 +1,29 @@
+"""
+This module provides testing utility for the backend
+Functions:
+- test_root_status(): Test API status
+- test_health(): #Test API health
+- test_chat_basic(): Baseline test for chatbot
+"""
 from fastapi.testclient import TestClient
 from .main import app
 
 client  = TestClient(app)
 
-#Test API status
 def test_root_status():
+    """Test API status"""
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Welcome to ThreadFlow API"}
 
-#Test health
 def test_health():
+    """Test health"""
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
 
-#Baseline test for chatbot
 def test_chat_basic():
+    """Baseline test for chatbot"""
     response = client.post("/chat", json={"message": "Hi!"})
     assert response.status_code == 200
-    assert "response" in response.json() 
+    assert "response" in response.json()


### PR DESCRIPTION
Reformatted main.py and test_api.py to pass lint tests.

Local testing results:
```
dhruv@LAPTOP-91GU63SJ:~/ThreadFlow/backend/app$ pylint test_api.py 

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

dhruv@LAPTOP-91GU63SJ:~/ThreadFlow/backend/app$ pylint main.py

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```